### PR TITLE
Update upgrade-hosts-and-reboot.py

### DIFF
--- a/scripts/upgrade-hosts-and-reboot.py
+++ b/scripts/upgrade-hosts-and-reboot.py
@@ -59,7 +59,7 @@ r = subprocess.run(f'''
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} ACTIVE_NETNS=$(ip netns |grep $(ip -br addr | grep wg_ | grep -o -e "WAN\S*" -e "ROOT\S*"| head -1) | cut -d " " -f1) enter' {nodes}
                     
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} "sudo ip netns exec \$ACTIVE_NETNS bash" enter' {nodes}
-                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} "touch /opt/ncubed/apt_lock" {nodes}
+                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} "touch /opt/ncubed/apt_lock"' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && DEBIAN_FRONTEND=noninteractive"' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && apt -y update"' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && apt -yq upgrade"' {nodes}

--- a/scripts/upgrade-hosts-and-reboot.py
+++ b/scripts/upgrade-hosts-and-reboot.py
@@ -63,8 +63,9 @@ r = subprocess.run(f'''
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && DEBIAN_FRONTEND=noninteractive"' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && apt -y update"' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && apt -yq upgrade"' {nodes}
-                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && exit"' {nodes}
-                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && rm /opt/ncubed/apt_lock" enter' {nodes}
+                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && rm /opt/ncubed/apt_lock"' {nodes}
+                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && exit" enter' {nodes}
+                    
                     ''',
                     shell=True, capture_output=True, text=True).stdout.strip("\n")
 

--- a/scripts/upgrade-hosts-and-reboot.py
+++ b/scripts/upgrade-hosts-and-reboot.py
@@ -60,9 +60,8 @@ r = subprocess.run(f'''
                     
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} "sudo ip netns exec \$ACTIVE_NETNS bash" enter' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} "touch /opt/ncubed/apt_lock"' {nodes}
-                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && DEBIAN_FRONTEND=noninteractive"' {nodes}
-                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && apt -y update"' {nodes}
-                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && apt -yq upgrade"' {nodes}
+                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && DEBIAN_FRONTEND=noninteractive apt -y update"' {nodes}
+                    ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && DEBIAN_FRONTEND=noninteractive apt -yq upgrade"' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && rm /opt/ncubed/apt_lock"' {nodes}
                     ansible -o -i {inventory_file} -m shell -a 'tmux send-keys -t {TERMINALID} " && exit" enter' {nodes}
                     


### PR DESCRIPTION
Added quote after `apt_lock" ` to fix the upgrade script. Switched exit to be after rm, instead of before.

The non interactive variable is now placed directly in front of the apt commands.

Fixes #4 
Fixes #6 
Fixes #7 